### PR TITLE
Remove compromised Valispace Participant Entry

### DIFF
--- a/pages/docs/participants-and-federators/ecosystem-participants.mdx
+++ b/pages/docs/participants-and-federators/ecosystem-participants.mdx
@@ -224,7 +224,6 @@ If you notice your a credential beeing outdated or an address missing here pleas
 | inovex GmbH 22.10                   | 0x4DdaE8989871DB4fAB65d62775e20c577340F8bE | Participant   | https://www.delta-dao.com/.well-known/2210_gx_participant_Inovex.json        |
 | neusta aerospace GmbH 22.10         | 0xAaeA7A824cffffFFf9Dd6EC51D7D7B0abA3f205F | Participant   | https://dpmo.dev.neusta.cooperants.info/.well-known/2210_gx_participant_neusta_aerospace_gmbh.json |
 | DLR GfR mbH 22.10                   | 0xf9eaebd346E9D414f4D4210CB12e43cc226038cF | Participant   | https://www.delta-dao.com/.well-known/2210_gx_participant_DLR.json       |
-| Valispace GmbH                      | 0xdbe749D939ea958aC64A5bdf163B05096E260572 | Participant   | https://www.valispace.com/.well-known/2210_gx_participant_Valispace.json     |
 | Valispace GmbH                      | 0x938224aC9e4832C517818B147BB1f6b10ADdCd26 | Participant   | https://www.valispace.com/.well-known/2210_gx_participant_Valispace.json     |
 | grandcentrix GmbH 22.10             | 0xAE823B7a6ad5b79da6d180Dbe91E7C810abAcCA4 | Participant   | https://www.delta-dao.com/.well-known/2210_gx_participant_grandcentrix.json  |
 | DIO 22.10                           | 0x2B9C7E0d7Be68ec6b519Dad050CD0A4bf130B6A4 | Participant   | https://www.delta-dao.com/.well-known/2210_gx_participant_DIO.json           |


### PR DESCRIPTION
Removing Valispace GmbH participant public address of the test-account that was created by DeltaDAO and not by Valispace GmbH
