### PR TITLE
chore: fix participants table formatting

### DIFF
--- a/pages/docs/participants-and-federators/ecosystem-participants.mdx
+++ b/pages/docs/participants-and-federators/ecosystem-participants.mdx
@@ -329,4 +329,4 @@ If you notice your a credential beeing outdated or an address missing here pleas
 | Universidad de Córdoba (UCO)                                   | 0x9A5F6f589171d55216cb1278Faf2701cfC4ab1F2 | Participant | https://compliance.agrospai.udl.cat/.well-known/UCO.vp.json |
 | Fruits de Ponent d’Alcarràs i Secció de Crèdit SCCL            | 0x179De85793A690308719AF9CD7D2F9BE0Db5ee90 | Participant | https://compliance.agrospai.udl.cat/.well-known/FruitsPonent.vp.json |
 | Centre Internacional de Mètodes Numèrics a l'Enginyeria - Buildings Energy and Environment Group | 0xFB6aaD927d026Ec21Ef8f699450Ed2ee416570a1 | Participant | https://compliance.agrospai.udl.cat/.well-known/BEEGroup-CIMNE.vp.json |
-| Empresas de Transformación Agraria, SA, SME, MP (Tragsa)       | 0x86cDDD03fDb7E4f62a4A31DA7483d370C03e96C8 | | Participant | https://compliance.agrospai.udl.cat/.well-known/Tragsa.vp.json |
+| Empresas de Transformación Agraria, SA, SME, MP (Tragsa)       | 0x86cDDD03fDb7E4f62a4A31DA7483d370C03e96C8 |  Participant | https://compliance.agrospai.udl.cat/.well-known/Tragsa.vp.json |


### PR DESCRIPTION
This fixes an issue in the participants table where an extra “|” (pipe) symbol was present, causing incorrect formatting.