### PR TITLE
Adds neusta aerospace participant description to the Gaia-X Trust Framework Participant Identification and Self-Descriptions list

### DIFF
--- a/pages/docs/participants-and-federators/federators.mdx
+++ b/pages/docs/participants-and-federators/federators.mdx
@@ -35,3 +35,4 @@ The Pontus-X network is powered by a diverse and distinguished group of validato
 - Exaion SAS: https://www.delta-dao.com/.well-known/participantExaion.json
 - AIRBUS: https://www.delta-dao.com/.well-known/2210_participant_AIRBUS_DS.json
 - Materna: https://www.delta-dao.com/.well-known/participantMaterna.json
+- Nneusta aerospace: https://aerospace-digital-exchange.eu/.well-known/2210_gx_participant_neusta_aerospace_gmbh.json


### PR DESCRIPTION
I added our participant description to the list "Gaia-X Trust Framework Participant Identification and Self-Descriptions"
